### PR TITLE
Adding more config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 - `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
 - `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
-- `additional_params`: A dictionary containing additional parameters to be added to the file. Keys will be uppercased, and values will be set as supplied.
+- `additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied.
 
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Role Variables
 - `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
 - `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
+- `additional_params`: A dictionary containing additional parameters to be added to the file. Keys will be uppercased, and values will be set as supplied.
 
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 - `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
 - `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
-- `additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied.
+- `network_additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied.
 
 The set of network parameters which can be defined in `network_ifaces` are as follows. If these are not defined, and the parameter has a default value, it will be added with that default value.
 - bondmaster (not a parameter, per se, but configures bonding. See example below.)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example Playbook
           dns1: 8.8.4.4
           dns2: 8.8.8.8
           network_additional_params:
-            ipv6_autoconf: no
+            ipv6_autoconf: "no"
 
     # Bonded network combining eth0 and eth1
     - hosts: localhost

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 - `network_ifaces[].bondmaster`: If specified this NIC will be part of a bonded interface. If the `device` name matches `bondmaster` it will be set as the master, otherwise it will be a slave of `bondmaster`.
 - `network_disable_ifaces`: A list of network device names to be explicitly disabled, use this if you want to be sure the interface is disabled (as opposed to being auto-configured by the system).
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
-- `network_additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied.
+- `network_additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied. Add this to the list of dictionaries, `network_ifaces`.
 
 The set of network parameters which can be defined in `network_ifaces` are as follows. If these are not defined, and the parameter has a default value, it will be added with that default value.
 - bondmaster (not a parameter, per se, but configures bonding. See example below.)
@@ -53,6 +53,8 @@ Example Playbook
           gateway: 192.168.1.254
           dns1: 8.8.4.4
           dns2: 8.8.8.8
+          network_additional_params:
+            ipv6_autoconf: no
 
     # Bonded network combining eth0 and eth1
     - hosts: localhost

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The set of network parameters which can be defined in `network_ifaces` are as fo
 - ovsbridge
 - prefix
 - type
+
+NB `ONBOOT=yes` is set by default, and is not configurable.
  
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -27,16 +27,13 @@ The set of network parameters which can be defined in `network_ifaces` are as fo
 - dns2
 - gateway
 - hwaddr
-- ipaddr
+- ip
 - ipv6init (default: yes)
 - mtu
 - netmask
-- nm_controlled
-- onboot
-- ovs_bridge
+- ovsbridge
 - prefix
 - type
-- userctl
  
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,27 @@ Role Variables
 - `network_delete_ifaces`: A regular expression describing the network device name(s) to be removed (note this means the system may auto-configure them), use this for cleaning up spare configuration files.
 - `additional_params`: A dictionary containing additional parameters to be added to the interface configuration file. Keys will be set to upper case, and values will be set as supplied.
 
-
+The set of network parameters which can be defined in `network_ifaces` are as follows. If these are not defined, and the parameter has a default value, it will be added with that default value.
+- bondmaster (not a parameter, per se, but configures bonding. See example below.)
+- bootproto (default: none)
+- bridge
+- device
+- devicetype
+- dns1
+- dns2
+- gateway
+- hwaddr
+- ipaddr
+- ipv6init (default: yes)
+- mtu
+- netmask
+- nm_controlled
+- onboot
+- ovs_bridge
+- prefix
+- type
+- userctl
+ 
 Example Playbook
 ----------------
 

--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -9,39 +9,6 @@ IPV6INIT={{ item.ipv6init }}
 {% else %}
 IPV6INIT=yes
 {% endif %}
-{% if 'defroute' in item %}
-DEFROUTE={{ item.defroute }}
-{% endif %}
-{% if 'domain' in item %}
-DOMAIN={{ item.domain }}
-{% endif %}
-{% if 'ipv4_failure_fatal' in item %}
-IPV4_FAILURE_FATAL={{ item.ipv4_failure_fatal }}
-{% endif %}
-{% if 'ipv6_addr_gen_mode' in item %}
-IPV6_ADDR_GEN_MODE={{ item.ipv6_addr_gen_mode }}
-{% endif %}
-{% if 'ipv6_autoconf' in item %}
-IPV6_AUTOCONF={{ item.ipv6_autoconf }}
-{% endif %}
-{% if 'ipv6_defroute' in item %}
-IPV6_DEFROUTE={{ item.ipv6_defroute }}
-{% endif %}
-{% if 'ipv6_failure_fatal' in item %}
-IPV6_FAILURE_FATAL={{ item.ipv6_failure_fatal }}
-{% endif %}
-{% if 'ipv6_peerdns' in item %}
-IPV6_PEERDNS={{ item.ipv6_peerdns }}
-{% endif %}
-{% if 'ipv6_peerroutes' in item %}
-IPV6_PEERROUTES={{ item.ipv6_peerroutes }}
-{% endif %}
-{% if 'name' in item %}
-NAME={{ item.name }}
-{% endif %}
-{% if 'uuid' in item %}
-UUID={{ item.uuid }}
-{% endif %}
 {% if 'mtu' in item and item['mtu'] %}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -47,10 +47,8 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
-{% if item.additional_params is defined and item.additional_params %}
-{%   for param, value in item.additional_params.items() %}{{ param|upper }}={{ value }}
-{%   endfor %}
-{% endif %}
+{% for param, value in ((item.additional_params.items() | default({})) | sort) %}{{ param|upper }}={{ value }}
+{% endfor %}
 {% if 'bondmaster' in item %}
 {%   if item.bondmaster == item.device %}
 {%     if 'type' not in item %}

--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -47,7 +47,7 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
-{% for param, value in ((item.additional_params.items() | default({})) | sort) %}{{ param|upper }}={{ value }}
+{% for param, value in ((item.network_additional_params.items() | default({})) | sort) %}{{ param|upper }}={{ value }}
 {% endfor %}
 {% if 'bondmaster' in item %}
 {%   if item.bondmaster == item.device %}

--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -9,6 +9,39 @@ IPV6INIT={{ item.ipv6init }}
 {% else %}
 IPV6INIT=yes
 {% endif %}
+{% if 'defroute' in item %}
+DEFROUTE={{ item.defroute }}
+{% endif %}
+{% if 'domain' in item %}
+DOMAIN={{ item.domain }}
+{% endif %}
+{% if 'ipv4_failure_fatal' in item %}
+IPV4_FAILURE_FATAL={{ item.ipv4_failure_fatal }}
+{% endif %}
+{% if 'ipv6_addr_gen_mode' in item %}
+IPV6_ADDR_GEN_MODE={{ item.ipv6_addr_gen_mode }}
+{% endif %}
+{% if 'ipv6_autoconf' in item %}
+IPV6_AUTOCONF={{ item.ipv6_autoconf }}
+{% endif %}
+{% if 'ipv6_defroute' in item %}
+IPV6_DEFROUTE={{ item.ipv6_defroute }}
+{% endif %}
+{% if 'ipv6_failure_fatal' in item %}
+IPV6_FAILURE_FATAL={{ item.ipv6_failure_fatal }}
+{% endif %}
+{% if 'ipv6_peerdns' in item %}
+IPV6_PEERDNS={{ item.ipv6_peerdns }}
+{% endif %}
+{% if 'ipv6_peerroutes' in item %}
+IPV6_PEERROUTES={{ item.ipv6_peerroutes }}
+{% endif %}
+{% if 'name' in item %}
+NAME={{ item.name }}
+{% endif %}
+{% if 'uuid' in item %}
+UUID={{ item.uuid }}
+{% endif %}
 {% if 'mtu' in item and item['mtu'] %}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -47,6 +47,10 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
+{% if item.additional_params is defined and item.additional_params %}
+{%   for param, value in item.additional_params.items() %}{{ param|upper }}={{ value }}
+{%   endfor %}
+{% endif %}
 {% if 'bondmaster' in item %}
 {%   if item.bondmaster == item.device %}
 {%     if 'type' not in item %}


### PR DESCRIPTION
Allow more config parameters to be configured by this role.

code-generated from an existing file with additional config params as follows:

```
 cat /etc/sysconfig/network-scripts/ifcfg-ens192 | \
cut -d "=" -f 1 | sort | uniq | \
awk '{print "{% if \x27"tolower($1)"\x27 in item %}"; print $1"={{ item."tolower($1)" }}"; print "{% endif %}"}'
```