### PR TITLE
BUGFIX: Remove incorrect .items() from network_additional_params

### DIFF
--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -47,7 +47,7 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
-{% for param, value in ((item.network_additional_params.items() | default({})) | sort) %}{{ param|upper }}={{ value }}
+{% for param, value in ((item.network_additional_params | default({})) | sort) %}{{ param|upper }}={{ value }}
 {% endfor %}
 {% if 'bondmaster' in item %}
 {%   if item.bondmaster == item.device %}


### PR DESCRIPTION
This is unnecessary, and causes an error if network_additional_params is not defined since `default()` only protects the first deference.

Tag: `1.1.1`