### PR TITLE
Don't use tuple when iterating through item.network_additional_params

### DIFF
--- a/templates/etc-sysconfig-network-scripts-ifcfg.j2
+++ b/templates/etc-sysconfig-network-scripts-ifcfg.j2
@@ -47,7 +47,7 @@ DNS2={{ item.dns2 }}
 BRIDGE={{ item.bridge }}
 {% endif %}
 USERCTL=no
-{% for param, value in ((item.network_additional_params | default({})) | sort) %}{{ param|upper }}={{ value }}
+{% for param in (item.network_additional_params | default([]) | sort) %}{{ param|upper }}={{ item.network_additional_params[param] }}
 {% endfor %}
 {% if 'bondmaster' in item %}
 {%   if item.bondmaster == item.device %}


### PR DESCRIPTION
Initial attempt at resolving #4

Iterating through a dictionary with a tuple seems to cause all sorts of problems (the bug in #3, the resulting issue in #4 caused by the attempt to fix #3). This is an attempt to get around these by iterating through keys only.

Currently untested but if someone has time to try it out that would be helpful. If more changes are needed feel free to push additional commits.
